### PR TITLE
[`Patch`] : Add correct `coreproject` url

### DIFF
--- a/Brewing.md
+++ b/Brewing.md
@@ -15,7 +15,7 @@ ___
 - [Atsumaru](https://atsu.moe/) [!badge variant="ghost" icon="mark-github" text="Github"](https://github.com/TheUndo/Atsumaru) `Mangasee scrapper`
 ==- Anime
 - [Anify](https://anify.tv/)
-- [CoreProject](https://github.com/baseplate-admin/CoreProject)
+- [CoreProject](https://coreproject.moe/anime)
 - [Streamable](https://streamable.moe/)
 ===
 


### PR DESCRIPTION
Hi there,

It seems that your project lists our project ( CoreProject ) Thank you very much for bringing attention to our project ( you rock ). But we have a domain `https://coreproject.moe`. 

It would be better if we pointed it to our domain ( dont you think? )

---

<sub>We are very close to launch actually</sub>

---

<sub> Also CoreProject is actually an umbrella of projects which includes </sub>
<sub> * AnimeCore ( anime  streaming ) </sub>
<sub> * SoundCore ( music streaming ) </sub>
<sub> * Forum ??? ( a modern forum software ) </sub>
</sub>
